### PR TITLE
feat: initial pre-commit hook for dclint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,63 @@
+name: Sync dclint version from npm
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  update:
+    name: Update dclint version
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get latest dclint version from npm
+        id: get_version
+        run: |
+          VERSION=$(npm show dclint version)
+          echo "Latest version is $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Extract current version from hooks
+        id: get_current
+        run: |
+          CURRENT=$(grep -o 'dclint@[0-9]\+\.[0-9]\+\.[0-9]\+' .pre-commit-hooks.yaml | head -1 | cut -d@ -f2)
+          echo "Current version is $CURRENT"
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+
+      - name: Compare versions
+        id: compare
+        run: |
+          if [ "${{ steps.get_version.outputs.version }}" != "${{ steps.get_current.outputs.current }}" ]; then
+            echo "Version changed"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No change"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Replace version in .pre-commit-hooks.yaml and README.md
+        if: steps.compare.outputs.changed == 'true'
+        run: |
+          NEW_VERSION=${{ steps.get_version.outputs.version }}
+          # Update npm version: dclint@x.y.z
+          sed -i "s/dclint@[0-9]\+\.[0-9]\+\.[0-9]\+/dclint@${NEW_VERSION}/g" .pre-commit-hooks.yaml
+          # Update docker version: dclint:vX.Y.Z
+          sed -i "s/zavoloklom\/dclint:v[0-9]\+\.[0-9]\+\.[0-9]\+/zavoloklom\/dclint:v${NEW_VERSION}/g" .pre-commit-hooks.yaml
+          # Update README.md
+          sed -i "s/rev: v[0-9]\+\.[0-9]\+\.[0-9]\+/rev: v${NEW_VERSION}/g" README.md
+
+      - name: Commit and tag new version
+        if: steps.compare.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add .pre-commit-hooks.yaml README.md
+          git commit -m "chore: update dclint to v${{ steps.get_version.outputs.version }}"
+          git tag v${{ steps.get_version.outputs.version }}
+          git push origin main --follow-tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# Misc
+.DS_Store
+
+# Envs
+.env
+
+# Dependencies
+/node_modules
+
+# Runtime
+/.tsimp

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,15 @@
+- id: dclint
+  name: DCLint
+  description: Validate and enforce best practices in Docker Compose files.
+  entry: dclint
+  language: node
+  additional_dependencies: [ "dclint@2.2.1" ]
+  types: [ yaml ]
+  files: ^(docker-)?compose\.ya?ml$
+- id: dclint-docker
+  name: DCLint via Docker
+  description: Validate and enforce best practices in Docker Compose files.
+  language: docker_image
+  entry: zavoloklom/dclint:v2.2.1
+  types: [ yaml ]
+  files: ^(docker-)?compose\.ya?ml$

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Sergey Kupletsky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
 # pre-commit-dclint
-Mirror of DCLint node package for pre-commit.
+
+Mirror of dclint package for pre-commit.
+
+- For `pre-commit`: see https://github.com/pre-commit/pre-commit
+- For `dclint`: see https://github.com/zavoloklom/docker-compose-linter
+
+This repository provides both a Node.js and Docker-based `pre-commit` hook to validate and enforce best practices
+automatically before committing.
+
+## Usage (Node.js)
+
+Add the following to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/docker-compose-linter/pre-commit-dclint
+    rev: v2.2.1  # Matches the dclint version, use the sha or tag you want to point at
+    hooks:
+      - id: dclint
+        # Optional: regex override for compose files
+        files: ^(docker-)?compose\.ya?ml
+        # Optional: enable autofix on commit
+        args: [ --fix ]  
+```
+
+## Usage (Docker)
+
+If you prefer not to install Node.js, you can run dclint via Docker:
+
+```yaml
+repos:
+- repo: https://github.com/docker-compose-linter/pre-commit-dclint
+  rev: v2.2.1 # Matches the dclint version, use the sha or tag you want to point at
+  hooks:
+    - id: dclint-docker
+      # Optional: regex override for compose files
+      files: ^(docker-)?compose\.ya?ml$
+      # Optional: enable autofix on commit
+      args: [--fix]
+```
+
+## Versioning
+
+This mirror is automatically updated to match the latest dclint version published on npm and docker registry.
+
+Version synchronization is maintained via GitHub Actions on a weekly schedule.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for more information.
+
+## Contacts and Support
+
+If you find this repository helpful, kindly consider showing your appreciation by giving it a star ⭐.
+
+If you have any questions or suggestions, feel free to reach out:
+
+- **Email**: [s.kupletsky@gmail.com](mailto:s.kupletsky@gmail.com)
+- **Х/Twitter**: [zavoloklom](https://x.com/zavoloklom)
+- **Instagram**: [zavoloklom](https://www.instagram.com/zavoloklom/)
+- **GitHub**: [zavoloklom](https://github.com/zavoloklom)
+
+Also, you can support this project with a donation:
+
+[![PayPal](https://img.shields.io/badge/PayPal-00457C?style=for-the-badge&logo=paypal&logoColor=white)](https://www.paypal.com/donate/?hosted_button_id=ZKLT8EJ4KWA6L)
+[![BuyMeACoffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)](https://www.buymeacoffee.com/zavoloklom)
+


### PR DESCRIPTION
Provides two hooks:
- `dclint`: node-based, installs from npm
- `dclint-docker`: docker-based, runs without Node.js

Automatically updated via GitHub Actions to match the latest dclint release.