### PR TITLE
Fix #2: Pre-commit hook fails with ERR_REQUIRE_ESM due to Node.js < 20

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,7 @@
   description: Validate and enforce best practices in Docker Compose files.
   entry: dclint
   language: node
+  language_version: 22.15.0
   additional_dependencies: [ "dclint@3.0.0" ]
   types: [ yaml ]
   files: ^(docker-)?compose\.ya?ml$


### PR DESCRIPTION
DCLint v3.0.0 requires Node.js >= 20.19.0 due to ESM module usage (e.g., yargs). Without this, users on systems like Ubuntu 24.04 (which defaults to Node 18) encounter `ERR_REQUIRE_ESM` errors.

This PR sets `language_version: 22.15.0` in the pre-commit hook config to ensure compatibility.

Fixes #2 
