### PR TITLE
Fix #3: Default files regex doesn't match nested compose.yaml files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,11 +6,11 @@
   language_version: 22.15.0
   additional_dependencies: [ "dclint@3.0.0" ]
   types: [ yaml ]
-  files: ^(docker-)?compose\.ya?ml$
+  files: '^(?:.*/)?(?:docker-)?compose\.ya?ml$'
 - id: dclint-docker
   name: DCLint via Docker
   description: Validate and enforce best practices in Docker Compose files.
   language: docker_image
   entry: zavoloklom/dclint:3.0.0
   types: [ yaml ]
-  files: ^(docker-)?compose\.ya?ml$
+  files: '^(?:.*/)?(?:docker-)?compose\.ya?ml$'

--- a/README.md
+++ b/README.md
@@ -30,15 +30,28 @@ If you prefer not to install Node.js, you can run dclint via Docker:
 
 ```yaml
 repos:
-- repo: https://github.com/docker-compose-linter/pre-commit-dclint
-  rev: v3.0.0 # Matches the dclint version, use the sha or tag you want to point at
-  hooks:
-    - id: dclint-docker
-      # Optional: regex override for compose files
-      files: ^(docker-)?compose\.ya?ml$
-      # Optional: enable autofix on commit
-      args: [--fix]
+  - repo: https://github.com/docker-compose-linter/pre-commit-dclint
+    rev: v3.0.0 # Matches the dclint version, use the sha or tag you want to point at
+    hooks:
+      - id: dclint-docker
+        # Optional: regex override for compose files
+        files: ^(docker-)?compose\.ya?ml$
+        # Optional: enable autofix on commit
+        args: [ --fix ]
 ```
+
+## CLI Arguments
+
+For a full list of supported CLI arguments, see
+the [official documentation](https://github.com/zavoloklom/docker-compose-linter/blob/main/docs/cli.md).
+
+Note that the `-r` (or `--recursive`) flag does not influence how pre-commit selects files to run hooks on. Instead,
+pre-commit uses the `files:` regex to determine which files should trigger the hook. This regex is applied to all
+changed file paths before the hook is invoked. If a file doesn’t match the pattern, the hook won’t run at all —
+regardless of whether `--recursive` is used internally.
+
+In this setup, the `files:` regex is already configured to match nested `compose.yaml` files, so pre-commit can
+correctly detect relevant changes and invoke the hook only when needed.
 
 ## Versioning
 


### PR DESCRIPTION
The current regex `^(docker-)?compose\.ya?ml$` only matches compose files in the repository root. This excludes valid files in subdirectories such as `roles/truenas_dockge/files/stacks/dockge/compose.yaml`.

This PR updates the pattern to `'^(?:.*/)?(?:docker-)?compose\.ya?ml$'` to allow matching in all paths.

Fixes #3 
